### PR TITLE
WIP: Fix Doc Map Type in wls logging exporter jenkins-ignore

### DIFF
--- a/src/main/java/weblogic/logging/exporter/LogExportHandler.java
+++ b/src/main/java/weblogic/logging/exporter/LogExportHandler.java
@@ -29,7 +29,7 @@ import weblogic.logging.exporter.config.FilterConfig;
 @SuppressWarnings("UnnecessaryContinue")
 class LogExportHandler extends Handler {
 
-  private static final String DOC_TYPE = "_doc";
+  private static final String DOC_TYPE = "doc";
   private static final String INDEX = " { \"index\" : { }} ";
   private static final int offValue = Level.OFF.intValue();
 


### PR DESCRIPTION
Changed Doc Map Type from "_doc" to "doc" in wls logging exporter 