### PR TITLE
Issue 9 Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ This section outlines the steps that are required to add the Weblogic Logging Ex
    It is also strongly recommended that you consider using a different Elastcsearch index name for each domain.
 
    If you prefer to place the configuration file in a different location, you can set the environment variable
-   `WEBLOGIC_LOGGING_EXPORTE_CONFIG_FILE` to point to the location of the file.
+   `WEBLOGIC_LOGGING_EXPORTER_CONFIG_FILE` to point to the location of the file.
 
 1. Restart the servers to activate the changes.  After restarting the servers, they will load the WebLogic
    Logging Exporter and start sending their logs to the specified Elasticsearch instance.  You can then

--- a/src/main/java/weblogic/logging/exporter/Startup.java
+++ b/src/main/java/weblogic/logging/exporter/Startup.java
@@ -27,8 +27,19 @@ public class Startup {
         If the file doesn't exist, give WARNING, and use default.
         It is assumed that when this is integrated to Operator, the system variable will be set.
       */
+
       String fileName =
-          System.getProperty("WEBLOGIC_LOGGING_EXPORTER_CONFIG_FILE", DEFAULT_CONFIG_FILE);
+          System.getProperty(
+              "WEBLOGIC_LOGGING_EXPORTER_CONFIG_FILE",
+              System.getenv("WEBLOGIC_LOGGING_EXPORTER_CONFIG_FILE"));
+      System.out.println(
+          "JavaProperty/EnvVariable WEBLOGIC_LOGGING_EXPORTER_CONFIG_FILE:" + fileName);
+      if (fileName == null || fileName.isEmpty()) {
+        System.out.println(
+            "Env variable WEBLOGIC_LOGGING_EXPORTER_CONFIG_FILE is not set. Defaulting to:"
+                + DEFAULT_CONFIG_FILE);
+        fileName = DEFAULT_CONFIG_FILE;
+      }
       File file = new File(fileName);
       System.out.println("Reading configuration from file name: " + file.getAbsolutePath());
       Config config = Config.loadConfig(file);


### PR DESCRIPTION
Fixed issue 9 https://github.com/oracle/weblogic-logging-exporter/issues/9
System will first check for system property, if not present it will check ENV variable, if not present it will default it.
Documentation talk only about global variable and not system property, I kept property read to keep retro compatibility. 
Fixed also a type on README.md about the variable name.

Signed-off-by: Stefano De Angelis <stefano.de.angelis@oracle.com>